### PR TITLE
Remove locale options as it causes a lot of confusion for users

### DIFF
--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -16,14 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CONF_LOCALE,
-    DATA_CLIENT,
-    DATA_COORDINATOR,
-    DOMAIN,
-    PLATFORMS,
-    STARTUP_MESSAGE,
-)
+from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN, PLATFORMS, STARTUP_MESSAGE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,13 +38,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     email = entry.data[CONF_EMAIL]
     password = entry.data[CONF_PASSWORD]
-    locale = entry.data[CONF_LOCALE]
     region = entry.data[CONF_REGION]
 
     client = MyT(
         username=email,
         password=password,
-        locale=locale,
+        locale="en-gb",
         region=region.lower(),
     )
 

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -13,8 +13,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_REGION
 
-from .const import CONF_LOCALE
-
 # https://github.com/PyCQA/pylint/issues/3202
 from .const import DOMAIN  # pylint: disable=unused-import
 
@@ -26,7 +24,6 @@ DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_EMAIL): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Required(CONF_LOCALE): str,
         vol.Required(CONF_REGION): vol.In(
             [region.capitalize() for region in supported_regions]
         ),
@@ -48,13 +45,12 @@ class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
 
             try:
-                locale = user_input[CONF_LOCALE]
                 region = user_input[CONF_REGION]
 
                 client = MyT(
                     username=user_input[CONF_EMAIL],
                     password=user_input[CONF_PASSWORD],
-                    locale=locale.lower(),
+                    locale="en-gb",
                     region=region.lower(),
                 )
 

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -7,7 +7,6 @@ NAME = "Toyota Connected Services"
 ISSUES_URL = "https://github.com/DurgNomis-drol/ha_toyota/issues"
 
 # CONF
-CONF_LOCALE = "locale"
 CONF_REGION_SUPPORTED = [
     "europe",
 ]

--- a/custom_components/toyota/translations/ca.json
+++ b/custom_components/toyota/translations/ca.json
@@ -7,7 +7,6 @@
         "data": {
           "email": "Correu electrònic",
           "password": "Contrasenya",
-          "locale": "Codi international de la llengua en format (ct-es)",
           "region": "Regió (Per ara unicament donem soport a Europa)"
         }
       }

--- a/custom_components/toyota/translations/da.json
+++ b/custom_components/toyota/translations/da.json
@@ -7,7 +7,6 @@
         "data": {
           "email": "Email",
           "password": "Adgangskode",
-          "locale": "Landekode i denne stil (da-dk)",
           "region": "Region (Kun Europa er understøttet lige nu)"
         }
       }

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -7,7 +7,6 @@
         "data": {
           "email": "Email",
           "password": "Password",
-          "locale": "Language code in this style (da-dk)",
           "region": "Region (Only Europe is supported right now)"
         }
       }

--- a/custom_components/toyota/translations/es.json
+++ b/custom_components/toyota/translations/es.json
@@ -7,7 +7,6 @@
         "data": {
           "email": "Dirección de correo electonico",
           "password": "Contraseña",
-          "locale": "Codigo internacional en la forma (es-es)",
           "region": "Región (Actualmente cubrimos solo a Europa)"
         }
       }

--- a/custom_components/toyota/translations/nl.json
+++ b/custom_components/toyota/translations/nl.json
@@ -7,7 +7,6 @@
         "data": {
           "email": "E-mail",
           "password": "Wachtwoord",
-          "locale": "Taalcode in deze vorm (nl-nl)",
           "region": "Regio (Alleen Europe is op dit moment ondersteund)"
         }
       }


### PR DESCRIPTION
After a little bit of testing, I have concluded that it is not necessary to have this option configurable. 

`en-gb` is now hardcoded and works with all countries in Europe