### PR TITLE
Fix attributes that are not converted to imperial

### DIFF
--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -24,14 +24,13 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    CONF_UNIT_SYSTEM_IMPERIAL_MPG,
     CONF_USE_LITERS_PER_100_MILES,
     DATA_CLIENT,
     DATA_COORDINATOR,
     DEFAULT_LOCALE,
     DOMAIN,
     PLATFORMS,
-    STARTUP_MESSAGE,
+    STARTUP_MESSAGE, CONF_UNIT_SYSTEM_IMPERIAL_LITERS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -84,10 +83,10 @@ async def async_setup_entry(  # pylint: disable=too-many-statements
                     _LOGGER.debug("The car is reporting data in imperial")
                     if use_liters:
                         _LOGGER.debug("Get statistics in imperial and L/100 miles")
-                        unit = CONF_UNIT_SYSTEM_IMPERIAL
+                        unit = CONF_UNIT_SYSTEM_IMPERIAL_LITERS
                     else:
                         _LOGGER.debug("Get statistics in imperial and MPG")
-                        unit = CONF_UNIT_SYSTEM_IMPERIAL_MPG
+                        unit = CONF_UNIT_SYSTEM_IMPERIAL
                 else:
                     _LOGGER.debug("The car is reporting data in metric")
                     unit = CONF_UNIT_SYSTEM_METRIC

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -11,13 +11,26 @@ from mytoyota.client import MyT
 from mytoyota.exceptions import ToyotaApiError, ToyotaInternalError, ToyotaLoginError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_REGION, LENGTH_MILES, CONF_UNIT_SYSTEM_METRIC, \
-    CONF_UNIT_SYSTEM_IMPERIAL
+from homeassistant.const import (
+    CONF_EMAIL,
+    CONF_PASSWORD,
+    CONF_REGION,
+    CONF_UNIT_SYSTEM_IMPERIAL,
+    CONF_UNIT_SYSTEM_METRIC,
+    LENGTH_MILES,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN, PLATFORMS, STARTUP_MESSAGE, CONF_USE_LITERS_PER_100_MILES
+from .const import (
+    CONF_USE_LITERS_PER_100_MILES,
+    DATA_CLIENT,
+    DATA_COORDINATOR,
+    DOMAIN,
+    PLATFORMS,
+    STARTUP_MESSAGE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,9 +87,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 # Use parallel request to get car statistics.
                 data = await asyncio.gather(
                     *[
-                        client.get_driving_statistics(vehicle.vin, interval="isoweek", unit=unit),
+                        client.get_driving_statistics(
+                            vehicle.vin, interval="isoweek", unit=unit
+                        ),
                         client.get_driving_statistics(vehicle.vin, unit=unit),
-                        client.get_driving_statistics(vehicle.vin, interval="year", unit=unit),
+                        client.get_driving_statistics(
+                            vehicle.vin, interval="year", unit=unit
+                        ),
                     ]
                 )
 

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -29,7 +29,7 @@ from .const import (
     DATA_COORDINATOR,
     DOMAIN,
     PLATFORMS,
-    STARTUP_MESSAGE,
+    STARTUP_MESSAGE, CONF_UNIT_SYSTEM_IMPERIAL_MPG, DEFAULT_LOCALE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     client = MyT(
         username=email,
         password=password,
-        locale="en-gb",
+        locale=DEFAULT_LOCALE,
         region=region.lower(),
     )
 
@@ -82,7 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     if use_liters:
                         unit = CONF_UNIT_SYSTEM_IMPERIAL
                     else:
-                        unit = "imperial_mpg"
+                        unit = CONF_UNIT_SYSTEM_IMPERIAL_MPG
 
                 # Use parallel request to get car statistics.
                 data = await asyncio.gather(

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -24,12 +24,14 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CONF_UNIT_SYSTEM_IMPERIAL_MPG,
     CONF_USE_LITERS_PER_100_MILES,
     DATA_CLIENT,
     DATA_COORDINATOR,
+    DEFAULT_LOCALE,
     DOMAIN,
     PLATFORMS,
-    STARTUP_MESSAGE, CONF_UNIT_SYSTEM_IMPERIAL_MPG, DEFAULT_LOCALE,
+    STARTUP_MESSAGE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,7 +46,9 @@ async def with_timeout(task, timeout_seconds=15):
         return await task
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(  # pylint: disable=too-many-statements
+    hass: HomeAssistant, entry: ConfigEntry
+):
     """Set up Toyota Connected Services from a config entry."""
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -24,13 +24,14 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CONF_UNIT_SYSTEM_IMPERIAL_LITERS,
     CONF_USE_LITERS_PER_100_MILES,
     DATA_CLIENT,
     DATA_COORDINATOR,
     DEFAULT_LOCALE,
     DOMAIN,
     PLATFORMS,
-    STARTUP_MESSAGE, CONF_UNIT_SYSTEM_IMPERIAL_LITERS,
+    STARTUP_MESSAGE,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -76,13 +76,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             for car in cars:
                 vehicle = await client.get_vehicle_status(car)
 
-                unit = CONF_UNIT_SYSTEM_METRIC
-
                 if vehicle.odometer.unit == LENGTH_MILES:
+                    _LOGGER.debug("The car is reporting data in imperial")
                     if use_liters:
+                        _LOGGER.debug("Get statistics in imperial and L/100 miles")
                         unit = CONF_UNIT_SYSTEM_IMPERIAL
                     else:
+                        _LOGGER.debug("Get statistics in imperial and MPG")
                         unit = CONF_UNIT_SYSTEM_IMPERIAL_MPG
+                else:
+                    _LOGGER.debug("The car is reporting data in metric")
+                    unit = CONF_UNIT_SYSTEM_METRIC
 
                 # Use parallel request to get car statistics.
                 data = await asyncio.gather(

--- a/custom_components/toyota/__init__.py
+++ b/custom_components/toyota/__init__.py
@@ -82,7 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     if use_liters:
                         unit = CONF_UNIT_SYSTEM_IMPERIAL
                     else:
-                        unit = CONF_UNIT_SYSTEM_IMPERIAL + "_mpg"
+                        unit = "imperial_mpg"
 
                 # Use parallel request to get car statistics.
                 data = await asyncio.gather(

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Toyota Connected Services integration."""
 import logging
 
-from homeassistant.core import callback
 from mytoyota.client import MyT
 from mytoyota.exceptions import (
     ToyotaInvalidUsername,
@@ -13,9 +12,13 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_REGION
+from homeassistant.core import callback
 
 # https://github.com/PyCQA/pylint/issues/3202
-from .const import DOMAIN, DATA_COORDINATOR, CONF_USE_LITERS_PER_100_MILES  # pylint: disable=unused-import
+from .const import (  # pylint: disable=unused-import
+    CONF_USE_LITERS_PER_100_MILES,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,9 +99,7 @@ class ToyotaOptionsFlowHandler(config_entries.OptionsFlow):
         # Cast from MappingProxy to dict to allow update.
         self.options = dict(config_entry.options)
 
-    async def async_step_init(
-        self, user_input=None
-    ):
+    async def async_step_init(self, user_input=None):
         """Manage the options."""
         if user_input is not None:
             self.options.update(user_input)

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -17,7 +17,8 @@ from homeassistant.core import callback
 # https://github.com/PyCQA/pylint/issues/3202
 from .const import (  # pylint: disable=unused-import
     CONF_USE_LITERS_PER_100_MILES,
-    DOMAIN, DEFAULT_LOCALE,
+    DEFAULT_LOCALE,
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/toyota/config_flow.py
+++ b/custom_components/toyota/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.core import callback
 # https://github.com/PyCQA/pylint/issues/3202
 from .const import (  # pylint: disable=unused-import
     CONF_USE_LITERS_PER_100_MILES,
-    DOMAIN,
+    DOMAIN, DEFAULT_LOCALE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class ToyotaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 client = MyT(
                     username=user_input[CONF_EMAIL],
                     password=user_input[CONF_PASSWORD],
-                    locale="en-gb",
+                    locale=DEFAULT_LOCALE,
                     region=region.lower(),
                 )
 

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -1,11 +1,7 @@
 """Constants for the Toyota Connected Services integration."""
 
 # PLATFORMS SUPPORTED
-PLATFORMS = [
-    "binary_sensor",
-    "sensor",
-    "device_tracker"
-]
+PLATFORMS = ["binary_sensor", "sensor", "device_tracker"]
 
 # INTEGRATION ATTRIBUTES
 DOMAIN = "toyota"

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -1,7 +1,13 @@
 """Constants for the Toyota Connected Services integration."""
 
-PLATFORMS = ["binary_sensor", "sensor", "device_tracker"]
+# PLATFORMS SUPPORTED
+PLATFORMS = [
+    "binary_sensor",
+    "sensor",
+    "device_tracker"
+]
 
+# INTEGRATION ATTRIBUTES
 DOMAIN = "toyota"
 NAME = "Toyota Connected Services"
 ISSUES_URL = "https://github.com/DurgNomis-drol/ha_toyota/issues"
@@ -10,7 +16,11 @@ ISSUES_URL = "https://github.com/DurgNomis-drol/ha_toyota/issues"
 CONF_REGION_SUPPORTED = [
     "europe",
 ]
+CONF_UNIT_SYSTEM_IMPERIAL_MPG = "imperial_mpg"
 CONF_USE_LITERS_PER_100_MILES = "use_liters"
+
+# DEFAULTS
+DEFAULT_LOCALE = "en-gb"
 
 # DATA COORDINATOR
 DATA_CLIENT = "toyota_client"
@@ -51,6 +61,7 @@ ICON_ODOMETER = "mdi:counter"
 ICON_HISTORY = "mdi:history"
 ICON_PARKING = "mdi:map-marker"
 
+# STARTUP LOG MESSAGE
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------
 {NAME}

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -12,7 +12,7 @@ ISSUES_URL = "https://github.com/DurgNomis-drol/ha_toyota/issues"
 CONF_REGION_SUPPORTED = [
     "europe",
 ]
-CONF_UNIT_SYSTEM_IMPERIAL_MPG = "imperial_mpg"
+CONF_UNIT_SYSTEM_IMPERIAL_LITERS = "imperial_liters"
 CONF_USE_LITERS_PER_100_MILES = "use_liters"
 
 # DEFAULTS

--- a/custom_components/toyota/const.py
+++ b/custom_components/toyota/const.py
@@ -10,6 +10,7 @@ ISSUES_URL = "https://github.com/DurgNomis-drol/ha_toyota/issues"
 CONF_REGION_SUPPORTED = [
     "europe",
 ]
+CONF_USE_LITERS_PER_100_MILES = "use_liters"
 
 # DATA COORDINATOR
 DATA_CLIENT = "toyota_client"

--- a/custom_components/toyota/entity.py
+++ b/custom_components/toyota/entity.py
@@ -71,7 +71,7 @@ class StatisticsBaseEntity(ToyotaBaseEntity, SensorEntity):
 
         def get_average_fuel_consumed(fuel_data):
             if FUEL_CONSUMED in fuel_data:
-                return fuel_data[FUEL_CONSUMED]
+                return round(fuel_data[FUEL_CONSUMED], 2)
             return STATE_UNAVAILABLE
 
         def get_timedelta(time):
@@ -84,7 +84,7 @@ class StatisticsBaseEntity(ToyotaBaseEntity, SensorEntity):
                 "Number_of_night_trips": statistics[NIGHT_TRIPS],
                 "Total_driving_time": get_timedelta(statistics[TOTAL_DURATION]),
                 "Average_speed": round(statistics[AVERAGE_SPEED], 1),
-                "Max_speed": statistics[MAX_SPEED],
+                "Max_speed": round(statistics[MAX_SPEED], 1),
             }
 
             if self.vehicle.details[HYBRID]:

--- a/custom_components/toyota/manifest.json
+++ b/custom_components/toyota/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/DurgNomis-drol/ha_toyota",
   "issue_tracker": "https://github.com/DurgNomis-drol/ha_toyota/issues",
   "codeowners": ["@DurgNomis-drol"],
-  "requirements": ["mytoyota==0.5.3", "arrow"],
+  "requirements": ["mytoyota==0.6.0", "arrow"],
   "version": "0.0.0",
   "iot_class": "cloud_polling"
 }

--- a/custom_components/toyota/manifest.json
+++ b/custom_components/toyota/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/DurgNomis-drol/ha_toyota",
   "issue_tracker": "https://github.com/DurgNomis-drol/ha_toyota/issues",
   "codeowners": ["@DurgNomis-drol"],
-  "requirements": ["mytoyota==0.6.0", "arrow"],
+  "requirements": ["mytoyota==0.6.1", "arrow"],
   "version": "0.0.0",
   "iot_class": "cloud_polling"
 }

--- a/custom_components/toyota/translations/da.json
+++ b/custom_components/toyota/translations/da.json
@@ -18,5 +18,14 @@
       "invalid_locale": "Landekode format er ikke korrekt.",
       "unknown": "Uventet fejl."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "use_liters": "Vis i liter (L/100 mil) i stedet for MPG. Gælder kun for biler der reportere deres data i mil."
+        }
+      }
+    }
   }
 }

--- a/custom_components/toyota/translations/en.json
+++ b/custom_components/toyota/translations/en.json
@@ -18,5 +18,14 @@
       "invalid_locale": "Language code is not valid.",
       "unknown": "Unexpected error."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "use_liters": "Use liters (L/100 miles) instead of MPG. Only applicable if you car reports data in miles (Imperial unit system)."
+        }
+      }
+    }
   }
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,7 +19,7 @@ speedups = ["aiodns", "brotlipy", "cchardet"]
 
 [[package]]
 name = "anyio"
-version = "3.3.0"
+version = "3.3.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
 optional = false
@@ -316,7 +316,7 @@ yarl = "1.6.3"
 
 [[package]]
 name = "httpcore"
-version = "0.13.6"
+version = "0.13.7"
 description = "A minimal low-level HTTP client."
 category = "main"
 optional = false
@@ -350,7 +350,7 @@ http2 = ["h2 (>=3.0.0,<4.0.0)"]
 
 [[package]]
 name = "identify"
-version = "2.2.13"
+version = "2.2.14"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -448,7 +448,7 @@ python-versions = "*"
 
 [[package]]
 name = "mytoyota"
-version = "0.5.3"
+version = "0.6.0"
 description = "Python client for Toyota Connected Services."
 category = "main"
 optional = false
@@ -771,7 +771,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "984735c472cbbf8a93a57538cabfd7110a7d917d59ce1f890583dd04358ef728"
+content-hash = "61d0be82f093658f42c08a3d2eda2a03503e5ec34961e0286bcc823cc42979bf"
 
 [metadata.files]
 aiohttp = [
@@ -814,8 +814,8 @@ aiohttp = [
     {file = "aiohttp-3.7.4.post0.tar.gz", hash = "sha256:493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf"},
 ]
 anyio = [
-    {file = "anyio-3.3.0-py3-none-any.whl", hash = "sha256:929a6852074397afe1d989002aa96d457e3e1e5441357c60d03e7eea0e65e1b0"},
-    {file = "anyio-3.3.0.tar.gz", hash = "sha256:ae57a67583e5ff8b4af47666ff5651c3732d45fd26c929253748e796af860374"},
+    {file = "anyio-3.3.1-py3-none-any.whl", hash = "sha256:d7c604dd491eca70e19c78664d685d5e4337612d574419d503e76f5d7d1590bd"},
+    {file = "anyio-3.3.1.tar.gz", hash = "sha256:85913b4e2fec030e8c72a8f9f98092eeb9e25847a6e00d567751b77e34f856fe"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -998,16 +998,16 @@ homeassistant = [
     {file = "homeassistant-2021.8.8.tar.gz", hash = "sha256:3343989b8ebecbabfd9808ea0783d12de801fef9d7085b6e419f478db36f5a10"},
 ]
 httpcore = [
-    {file = "httpcore-0.13.6-py3-none-any.whl", hash = "sha256:db4c0dcb8323494d01b8c6d812d80091a31e520033e7b0120883d6f52da649ff"},
-    {file = "httpcore-0.13.6.tar.gz", hash = "sha256:b0d16f0012ec88d8cc848f5a55f8a03158405f4bca02ee49bc4ca2c1fda49f3e"},
+    {file = "httpcore-0.13.7-py3-none-any.whl", hash = "sha256:369aa481b014cf046f7067fddd67d00560f2f00426e79569d99cb11245134af0"},
+    {file = "httpcore-0.13.7.tar.gz", hash = "sha256:036f960468759e633574d7c121afba48af6419615d36ab8ede979f1ad6276fa3"},
 ]
 httpx = [
     {file = "httpx-0.18.2-py3-none-any.whl", hash = "sha256:979afafecb7d22a1d10340bafb403cf2cb75aff214426ff206521fc79d26408c"},
     {file = "httpx-0.18.2.tar.gz", hash = "sha256:9f99c15d33642d38bce8405df088c1c4cfd940284b4290cacbfb02e64f4877c6"},
 ]
 identify = [
-    {file = "identify-2.2.13-py2.py3-none-any.whl", hash = "sha256:7199679b5be13a6b40e6e19ea473e789b11b4e3b60986499b1f589ffb03c217c"},
-    {file = "identify-2.2.13.tar.gz", hash = "sha256:7bc6e829392bd017236531963d2d937d66fc27cadc643ac0aba2ce9f26157c79"},
+    {file = "identify-2.2.14-py2.py3-none-any.whl", hash = "sha256:113a76a6ba614d2a3dd408b3504446bcfac0370da5995aa6a17fd7c6dffde02d"},
+    {file = "identify-2.2.14.tar.gz", hash = "sha256:32f465f3c48083f345ad29a9df8419a4ce0674bf4a8c3245191d65c83634bdbf"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1132,8 +1132,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 mytoyota = [
-    {file = "mytoyota-0.5.3-py3-none-any.whl", hash = "sha256:6b00f4b2729bd8b2f1a901d99491747ac51eff4d49172234a6e914b54c72f08d"},
-    {file = "mytoyota-0.5.3.tar.gz", hash = "sha256:d5d686637e67ed076a5a87bf4eaf279f8ab68c39f0cebd1defda745bae279c57"},
+    {file = "mytoyota-0.6.0-py3-none-any.whl", hash = "sha256:97d86091b98a51de160913bdb5e048bc6d03a8933cbe22a09aa9c4c2a91a1ee6"},
+    {file = "mytoyota-0.6.0.tar.gz", hash = "sha256:fb689d1049de3476beb0c758041b42d78f5722fcbe03b94340ea4a4222ca22d3"},
 ]
 nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toyota"
-version = "1.0.2"
+version = "0.0.0"
 description = "Toyota Connected Services integration for Home Assistant"
 authors = ["DurgNomis-drol <simongrud@gmail.com>"]
 license = "MIT"
@@ -8,7 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.8"
 homeassistant = "^2021.3.3"
-mytoyota = "0.5.3"
+mytoyota = "0.6.0"
 arrow = "^1.1.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This fixes the problem with attributes not in imperial unit system when the car reports in imperial unit system.

This also adds the ability for users, who's cars reports in the imperial unit system, to use either MPG or L/100 miles.

Closes #56 