### PR TITLE
Change EV battery name to EV battery status

### DIFF
--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -62,7 +62,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
                 sensors.append(ToyotaRangeSensor(coordinator, index, "range"))
 
             if vehicle.energy.chargeinfo:
-                sensors.append(ToyotaEVSensor(coordinator, index, "EV battery"))
+                sensors.append(ToyotaEVSensor(coordinator, index, "EV battery status"))
 
             sensors.extend(
                 [


### PR DESCRIPTION
This have lead to confusion, expecting it to show how much is left in the battery