### PR TITLE
Move starter battery sensor to a binary sensor

### DIFF
--- a/custom_components/toyota/binary_sensor.py
+++ b/custom_components/toyota/binary_sensor.py
@@ -36,6 +36,8 @@ class ToyotaBinaryEntityDescription(
 ):
     """Describes a Toyota binary entity."""
 
+
+
 STARTER_BATTERY_HEALTH_ENTITY_DESCRIPTIONS = ToyotaBinaryEntityDescription(
     key="starter_battery_health",
     name="Starter battery health",

--- a/custom_components/toyota/binary_sensor.py
+++ b/custom_components/toyota/binary_sensor.py
@@ -36,6 +36,15 @@ class ToyotaBinaryEntityDescription(
 ):
     """Describes a Toyota binary entity."""
 
+STARTER_BATTERY_HEALTH_ENTITY_DESCRIPTIONS = ToyotaBinaryEntityDescription(
+    key="starter_battery_health",
+    name="Starter battery health",
+    icon="mdi:car-battery",
+    device_class=BinarySensorDeviceClass.PROBLEM,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    value_fn=lambda vh: vh.details.get("batteryHealth") == "good",
+    attributes_fn=lambda vh: None,
+)
 
 OVER_ALL_STATUS_ENTITY_DESCRIPTION = ToyotaBinaryEntityDescription(
     key="over_all_status",
@@ -298,6 +307,16 @@ async def async_setup_entry(
 
     for index, vehicle in enumerate(coordinator.data):
         vehicle = coordinator.data[index]["data"]
+
+        if vehicle.details.get("batteryHealth") is not None:
+            binary_sensors.append(
+                ToyotaBinarySensor(
+                    coordinator=coordinator,
+                    entry_id=entry.entry_id,
+                    vehicle_index=index,
+                    description=STARTER_BATTERY_HEALTH_ENTITY_DESCRIPTIONS,
+                )
+            )
 
         if vehicle.is_connected_services_enabled:
             if vehicle.hvac and vehicle.hvac.legacy:

--- a/custom_components/toyota/entity.py
+++ b/custom_components/toyota/entity.py
@@ -15,6 +15,7 @@ from .const import DOMAIN
 
 class ToyotaBaseEntity(CoordinatorEntity):
     """Defines a base Toyota entity."""
+    
     _attr_has_entity_name = True
 
     def __init__(

--- a/custom_components/toyota/sensor.py
+++ b/custom_components/toyota/sensor.py
@@ -61,16 +61,6 @@ LICENSE_PLATE_ENTITY_DESCRIPTION = ToyotaSensorEntityDescription(
     value_fn=lambda vehicle: vehicle.details.get(LICENSE_PLATE, STATE_UNKNOWN),
     attributes_fn=lambda vehicle: vehicle.details,
 )
-STARTER_BATTERY_HEALTH_ENTITY_DESCRIPTIONS = ToyotaSensorEntityDescription(
-    key="starter_battery_health",
-    translation_key="starter_battery_health",
-    icon="mdi:car_battery",
-    device_class=SensorDeviceClass.ENUM,
-    native_unit_of_measurement=None,
-    state_class=None,
-    value_fn=lambda vehicle: vehicle.details.get("batteryHealth").capitalize(),
-    attributes_fn=lambda vehicle: None,
-)
 ODOMETER_ENTITY_DESCRIPTION_KM = ToyotaSensorEntityDescription(
     key="odometer",
     translation_key="odometer",
@@ -193,16 +183,6 @@ async def async_setup_entry(
                         description=description,
                     )
                 )
-
-        if vehicle.details.get("batteryHealth") is not None:
-            sensors.append(
-                ToyotaSensor(
-                    coordinator=coordinator,
-                    entry_id=entry.entry_id,
-                    vehicle_index=index,
-                    description=STARTER_BATTERY_HEALTH_ENTITY_DESCRIPTIONS,
-                )
-            )
 
         sensors.append(
             ToyotaSensor(


### PR DESCRIPTION
I think it makes more sense to move this to a `binary_sensor`.